### PR TITLE
Update setup.py with correct nbpdfexport version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
 	],
 	install_requires = [
 		"nbformat",
-		"nbpdfexport==0.2.2",
+		"nbpdfexport==0.2.1",
 		"codecov",
 		"IPython"
 	],


### PR DESCRIPTION
Installing nbpdfexport with v0.2.2 fails. This also affects upstream projects such as otter-grader.

@chrispyles let me know if something is missing. Thanks!